### PR TITLE
Fix Start agent in installation.rst

### DIFF
--- a/admin/installation.rst
+++ b/admin/installation.rst
@@ -445,13 +445,13 @@ Start agent
 
 .. code-block:: sh
 
-  systemctl start nxagentd
+  systemctl start netxms-agent
 
 Enable automatic startup of agent
 
 .. code-block:: sh
 
-  systemctl enable nxagentd
+  systemctl enable netxms-agent
 
 
 Management Client


### PR DESCRIPTION
The command in the documentation gives an error:
![grafik](https://github.com/netxms/netxms-doc/assets/27882680/5d3613e2-8fac-43f8-8e24-ae54cdb6506b)

This is a fix for that.