### PR TITLE
Improve Linux kernel tuning section

### DIFF
--- a/admin/installation.rst
+++ b/admin/installation.rst
@@ -320,18 +320,36 @@ The following kernel parameters should be changed:
 * net.core.rmem_max
 * net.core.wmem_max
 
-In our test lab, value 1703936 seems to be working well (default was 212992).
-
-Example:
-
-* sudo sysctl -w net.core.rmem_default=1703936
-* sudo sysctl -w net.core.wmem_default=1703936
-* sudo sysctl -w net.core.rmem_max=1703936
-* sudo sysctl -w net.core.wmem_max=1703936
-
-Kernel changes will not be preserved after reboot unless sysctl commands are applied in the system
-configuration file, which is typically located at /etc/sysctl.conf. Increasing these kernel values also
+In our test lab, value 1703936 seems to be working well (default was 212992). Increasing these kernel values also
 increases kernel memory space in use and may impact other applications.
+
+To make the changes persistent across reboots, edit the ``/etc/sysctl.conf`` file:
+
+.. code-block:: sh
+
+   sudo nano /etc/sysctl.conf
+
+Add the following lines at the end of the file:
+
+.. code-block:: ini
+
+   # Increase network buffer size for NetXMS
+   net.core.rmem_default=1703936
+   net.core.wmem_default=1703936
+   net.core.rmem_max=1703936
+   net.core.wmem_max=1703936
+
+After saving the file, load the new settings by running:
+
+.. code-block:: sh
+
+   sudo sysctl -p
+
+To verify that the settings have been successfully applied, run:
+
+.. code-block:: sh
+
+   sysctl net.core.rmem_default net.core.wmem_default net.core.rmem_max net.core.wmem_max
 
 Database
 --------


### PR DESCRIPTION
This pull request updates the installation documentation to provide clearer and more persistent instructions for configuring kernel network buffer parameters. The changes improve guidance on making these settings persistent across reboots.

Kernel parameter configuration improvements:

* Added instructions to edit the `/etc/sysctl.conf` file for persistent kernel parameter changes, replacing temporary `sysctl` commands.
* Included example configuration lines and verification steps to ensure settings are applied correctly.