### PR TITLE
Remove network.target from systemd After dependency

### DIFF
--- a/admin/installation.rst
+++ b/admin/installation.rst
@@ -643,7 +643,7 @@ Provided driver packages:
    .. code-block:: sh
 
      [Unit]
-     After=network.target postgresql.service
+     After=postgresql.service
 
    After editing, run ``systemctl daemon-reload`` to reload systemd
    configuration.

--- a/admin/installation.rst
+++ b/admin/installation.rst
@@ -477,7 +477,7 @@ Provided driver packages:
    .. code-block:: sh
 
      [Unit]
-     After=network.target postgresql.service
+     After=postgresql.service
 
    After editing run ``systemctl daemon-reload`` to reload systemd
    configuration.


### PR DESCRIPTION
We don't need `After=network.target` here, because it is already included in [netxms-server.service](https://github.com/netxms/packages-deb/blob/stable-6.0/netxms-server.service).

You can verify it by running:
```bash
systemctl show netxms-server.service -p After
```